### PR TITLE
Fix ability to click Asset Viewer when Relationships Viewer is visible

### DIFF
--- a/src/containers/Main.tsx
+++ b/src/containers/Main.tsx
@@ -226,7 +226,11 @@ class Main extends React.Component<Props, State> {
   };
 
   onAssetViewerChange = (visible: boolean) => {
-    this.setState({ showAssetViewer: visible });
+    const { showRelationships } = this.state;
+    this.setState({
+      showAssetViewer: visible,
+      showRelationships: visible ? false : showRelationships,
+    });
     localStorage.setItem('showAssetViewer', `${visible}`);
   };
 


### PR DESCRIPTION
Tiny little UI fix with the Asset Network Viewer / Relationships Viewer switches. My first fix! Woohoo!